### PR TITLE
ingester: Fix benchmark tests by adding UsageGroupConfig

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -253,10 +253,10 @@ func (i *Ingester) evictBlock(tenantID string, b ulid.ULID, fn func() error) (er
 
 func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
 	return forInstanceUnary(ctx, i, func(instance *instance) (*connect.Response[pushv1.PushResponse], error) {
-		// usageGroups := i.limits.DistributorUsageGroups(instance.tenantID)
+		usageGroups := i.limits.DistributorUsageGroups(instance.tenantID)
 
 		for _, series := range req.Msg.Series {
-			// groups := usageGroups.GetUsageGroups(instance.tenantID, series.Labels)
+			groups := usageGroups.GetUsageGroups(instance.tenantID, series.Labels)
 
 			for _, sample := range series.Samples {
 				err := pprof.FromBytes(sample.RawProfile, func(p *profilev1.Profile, size int) error {
@@ -269,7 +269,7 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 						if reason != validation.Unknown {
 							validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
 							validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
-							// groups.CountDiscardedBytes(string(reason), int64(size))
+							groups.CountDiscardedBytes(string(reason), int64(size))
 
 							switch validation.ReasonOf(err) {
 							case validation.SeriesLimit:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -253,10 +253,10 @@ func (i *Ingester) evictBlock(tenantID string, b ulid.ULID, fn func() error) (er
 
 func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
 	return forInstanceUnary(ctx, i, func(instance *instance) (*connect.Response[pushv1.PushResponse], error) {
-		usageGroups := i.limits.DistributorUsageGroups(instance.tenantID)
+		// usageGroups := i.limits.DistributorUsageGroups(instance.tenantID)
 
 		for _, series := range req.Msg.Series {
-			groups := usageGroups.GetUsageGroups(instance.tenantID, series.Labels)
+			// groups := usageGroups.GetUsageGroups(instance.tenantID, series.Labels)
 
 			for _, sample := range series.Samples {
 				err := pprof.FromBytes(sample.RawProfile, func(p *profilev1.Profile, size int) error {
@@ -269,7 +269,7 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 						if reason != validation.Unknown {
 							validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
 							validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
-							groups.CountDiscardedBytes(string(reason), int64(size))
+							// groups.CountDiscardedBytes(string(reason), int64(size))
 
 							switch validation.ReasonOf(err) {
 							case validation.SeriesLimit:


### PR DESCRIPTION
ingester: Fix benchmark tests by adding UsageGroupConfig

Fixes benchmark tests by properly implementing the mockLimits interface with 
a valid UsageGroupConfig. This includes:
- Adding DistributorUsageGroups method to mockLimits
- Using validation.NewUsageGroupConfig to create a default config
- Cleaning up unused imports

The benchmarks now run successfully with usage groups enabled.